### PR TITLE
Add `servers` database to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mongo_playground.py
 Cogs/nitro.py
 Cogs/votecog.py
 Cogs/pets.py
+servers


### PR DESCRIPTION
In my view, it's a privacy violation to have the database be exposed.